### PR TITLE
handle unknown fields in XenonResponse to prevent deserialization fai…

### DIFF
--- a/src/main/java/in/handyman/raven/lib/model/deep/sift/XenonResponse.java
+++ b/src/main/java/in/handyman/raven/lib/model/deep/sift/XenonResponse.java
@@ -1,6 +1,7 @@
 package in.handyman.raven.lib.model.deep.sift;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import in.handyman.raven.lib.model.kvp.llm.radon.processor.ComputationDetails;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,7 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.UUID;
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @Builder
 @AllArgsConstructor


### PR DESCRIPTION
DeepSift XENON extraction was failing due to an unrecognized metricsData field in the model response. The issue was resolved by updating the XenonResponse model to safely ignore unknown properties, restoring successful processing and case creation.