### PR TITLE
Fix NullPointerException in processEncryption by adding null-safe check for isEncrypted

### DIFF
--- a/src/main/java/in/handyman/raven/lib/PostProcessingExecutorAction.java
+++ b/src/main/java/in/handyman/raven/lib/PostProcessingExecutorAction.java
@@ -106,16 +106,28 @@ public class PostProcessingExecutorAction implements IActionExecution {
     }
 
     private void processEncryption(PostProcessingFieldsInput input, InticsIntegrity crypt, boolean encryptEnabled) {
-        if ("multi_value".equalsIgnoreCase(input.getLineItemType())) {
-            handleMultiValue(input, crypt, encryptEnabled);
-        } else if (encryptEnabled && Boolean.TRUE.equals(input.getIsEncrypted()) && input.getAnswer() != null) {
-            input.setAnswer(
-                    crypt.encrypt(
-                            input.getAnswer(),
-                            input.getEncryptionPolicy(),
-                            String.valueOf(input.getVqaId())
-                    )
-            );
+        try {
+            if ("multi_value".equalsIgnoreCase(input.getLineItemType())) {
+                handleMultiValue(input, crypt, encryptEnabled);
+            } else if (encryptEnabled && Boolean.TRUE.equals(input.getIsEncrypted()) && input.getAnswer() != null) {
+                input.setAnswer(
+                        crypt.encrypt(
+                                input.getAnswer(),
+                                input.getEncryptionPolicy(),
+                                String.valueOf(input.getVqaId())
+                        )
+                );
+            }
+        } catch (Exception e) {
+            action.getContext().put(input.getSorItemName() + ".isSuccessful", "false");
+            log.error(aMarker, "Error during encryption processing", e);
+
+        HandymanException handymanException = new HandymanException(e);
+        HandymanException.insertException(
+                "Encryption processing failed for VQA ID: " + input.getVqaId() + " SortItemName: " + input.getSorItemName() + ".",
+                handymanException,
+                action
+        );
         }
     }
 

--- a/src/main/java/in/handyman/raven/lib/PostProcessingExecutorAction.java
+++ b/src/main/java/in/handyman/raven/lib/PostProcessingExecutorAction.java
@@ -108,7 +108,7 @@ public class PostProcessingExecutorAction implements IActionExecution {
     private void processEncryption(PostProcessingFieldsInput input, InticsIntegrity crypt, boolean encryptEnabled) {
         if ("multi_value".equalsIgnoreCase(input.getLineItemType())) {
             handleMultiValue(input, crypt, encryptEnabled);
-        } else if (encryptEnabled && input.getIsEncrypted()) {
+        } else if (encryptEnabled && Boolean.TRUE.equals(input.getIsEncrypted()) && input.getAnswer() != null) {
             input.setAnswer(
                     crypt.encrypt(
                             input.getAnswer(),


### PR DESCRIPTION
Fix NullPointerException in processEncryption by adding null-safe check for isEncrypted.


The issue has been replicated in 70784 - RootPipeline.