### PR TITLE
instead of id - instance is changed

### DIFF
--- a/src/main/java/in/handyman/raven/lib/adapters/selections/LabelWithPriorityProcessor.java
+++ b/src/main/java/in/handyman/raven/lib/adapters/selections/LabelWithPriorityProcessor.java
@@ -275,8 +275,10 @@ public class LabelWithPriorityProcessor {
                 originId, sorItemName);
 
         SelectionFilteringInputTable winner = rows.stream()
-                .min(Comparator.comparingLong(SelectionFilteringInputTable::getPaperNo)
-                        .thenComparingLong(SelectionFilteringInputTable::getId))
+                .min(Comparator
+                        .comparingLong(SelectionFilteringInputTable::getPaperNo)
+                        .thenComparingInt(r -> extractInstanceIndex(r.getSorContainerInstance()))
+                )
                 .orElseThrow();
 
         logger.info("[originId: {}, sorItemName: {}, paperNo: {}] Winner selected - id: {}",
@@ -286,7 +288,7 @@ public class LabelWithPriorityProcessor {
             r.setLabelMatching(r == winner);
             r.setLabelPriorityIdx("N/A");
             r.setLabelMatchMessage(appendMsg(r,
-                    r == winner ? "No label priority → selected min paperNo/id"
+                    r == winner ? "No label priority → selected min paperNo/Instance"
                             : "No label priority → not selected"));
         });
 
@@ -424,7 +426,16 @@ public class LabelWithPriorityProcessor {
                         .min(Comparator
                                 .comparingLong(SelectionFilteringInputTable::getPaperNo)
                                 .thenComparing((SelectionFilteringInputTable r) -> !hasNonEmptyAnswer(r))
-                                .thenComparingLong(SelectionFilteringInputTable::getId)
+                                .thenComparing((r1, r2) -> {
+                                    // Only apply instance comparison when paperNo is SAME
+                                    if (Objects.equals(r1.getPaperNo(), r2.getPaperNo())) {
+                                        return Integer.compare(
+                                                extractInstanceIndex(r1.getSorContainerInstance()),
+                                                extractInstanceIndex(r2.getSorContainerInstance())
+                                        );
+                                    }
+                                    return 0;
+                                })
                         )
                         .orElseThrow();
 
@@ -438,19 +449,32 @@ public class LabelWithPriorityProcessor {
 
                 if (samePageCount > 1) {
                     winner.setLabelMatchMessage(
-                            appendMsg(winner, "Same label on page " + winnerPageNo +
-                                    " → selected with answer/min id=" + winner.getId())
+                            appendMsg(winner,
+                                    "Same label on page " + winnerPageNo +
+                                            " → selected with answer/min instance=" + winner.getSorContainerInstance()
+                            )
                     );
                 } else {
                     winner.setLabelMatchMessage(
-                            appendMsg(winner, "Same labels → selected min paperNo=" + winner.getPaperNo())
+                            appendMsg(winner,
+                                    "Same labels → selected min paperNo/instance=" + winner.getSorContainerInstance()
+                            )
                     );
                 }
             } else {
                 winner = topPriorityRows.stream()
                         .min(Comparator
                                 .comparing((SelectionFilteringInputTable r) -> !hasNonEmptyAnswer(r))
-                                .thenComparingLong(SelectionFilteringInputTable::getId)
+                                .thenComparing((r1, r2) -> {
+                                    // Apply instance comparison ONLY when paperNo is same
+                                    if (Objects.equals(r1.getPaperNo(), r2.getPaperNo())) {
+                                        return Integer.compare(
+                                                extractInstanceIndex(r1.getSorContainerInstance()),
+                                                extractInstanceIndex(r2.getSorContainerInstance())
+                                        );
+                                    }
+                                    return 0;
+                                })
                         )
                         .orElseThrow();
 
@@ -470,11 +494,11 @@ public class LabelWithPriorityProcessor {
                     );
                 } else if (allEqualAnswers) {
                     winner.setLabelMatchMessage(
-                            appendMsg(winner, "Equal answers → selected min id")
+                            appendMsg(winner, "Equal answers → selected min instance")
                     );
                 } else {
                     winner.setLabelMatchMessage(
-                            appendMsg(winner, "Selected min id (no answers present)")
+                            appendMsg(winner, "Selected min instance (no answers present)")
                     );
                 }
             }
@@ -488,7 +512,7 @@ public class LabelWithPriorityProcessor {
                         appendMsg(r, "Rejected: " +
                                 (hasNonEmptyAnswer(winner) && !hasNonEmptyAnswer(r)
                                         ? "winner has answer"
-                                        : "lower paperNo/id chosen"))
+                                        : "lower paperNo/Instance chosen"))
                 );
             }
         }
@@ -598,5 +622,16 @@ public class LabelWithPriorityProcessor {
         String existing = row.getLabelMatchMessage();
         if (existing == null || existing.isBlank()) return msgWithPriority;
         return existing + " | " + msgWithPriority;
+    }
+
+    private int extractInstanceIndex(String instance) {
+        if (instance == null || instance.isBlank()) return Integer.MAX_VALUE;
+        try {
+            int idx = instance.lastIndexOf("_");
+            if (idx != -1 && idx + 1 < instance.length()) {
+                return Integer.parseInt(instance.substring(idx + 1));
+            }
+        } catch (Exception ignored) {}
+        return Integer.MAX_VALUE;
     }
 }

--- a/src/test/java/in/handyman/raven/lib/adapters/selections/LabelWithPriorityProcessorTest.java
+++ b/src/test/java/in/handyman/raven/lib/adapters/selections/LabelWithPriorityProcessorTest.java
@@ -3,6 +3,7 @@ package in.handyman.raven.lib.adapters.selections;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import in.handyman.raven.lib.adapters.selections.models.AggregationEvaluatorInputModel;
+import in.handyman.raven.lib.adapters.selections.models.SelectionFilteringInputTable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -427,5 +428,83 @@ class LabelWithPriorityProcessorTest {
 //        r.setPaperNo(1);
 //        return r;
 //    }
+
+    @Test
+    void testHandlePriorityBasedSelection_instanceTieBreaker() throws Exception {
+
+        ObjectMapper mapper = new ObjectMapper();
+        Logger logger = Mockito.mock(Logger.class);
+
+        LabelWithPriorityProcessor processor =
+                new LabelWithPriorityProcessor(mapper, logger);
+
+        // Prepare rows
+        SelectionFilteringInputTable row1 = new SelectionFilteringInputTable();
+        row1.setId(1L);
+        row1.setOriginId("1");
+        row1.setSorItemName("member");
+        row1.setSorItemLabel("A");
+        row1.setAnswer("value");
+        row1.setPaperNo(1L);
+        row1.setSorContainerInstance("MEMBER_DETAILS_2");
+        row1.setWhitelistedLabelsWithPriority("[{\"whitelistKey\":\"A\",\"labelPriority\":1}]");
+
+        SelectionFilteringInputTable row2 = new SelectionFilteringInputTable();
+        row2.setId(2L);
+        row2.setOriginId("1");
+        row2.setSorItemName("member");
+        row2.setSorItemLabel("A");
+        row2.setAnswer("value");
+        row2.setPaperNo(1L);
+        row2.setSorContainerInstance("MEMBER_DETAILS_0");
+        row2.setWhitelistedLabelsWithPriority("[{\"whitelistKey\":\"A\",\"labelPriority\":1}]");
+
+        SelectionFilteringInputTable row3 = new SelectionFilteringInputTable();
+        row3.setId(3L);
+        row3.setOriginId("1");
+        row3.setSorItemName("member");
+        row3.setSorItemLabel("A");
+        row3.setAnswer("value");
+        row3.setPaperNo(1L);
+        row3.setSorContainerInstance("MEMBER_DETAILS_1");
+        row3.setWhitelistedLabelsWithPriority("[{\"whitelistKey\":\"A\",\"labelPriority\":1}]");
+
+        List<SelectionFilteringInputTable> rows = Arrays.asList(row1, row2, row3);
+
+        // Prepare priority map manually
+        Map<String, Integer> priorityMap = new HashMap<>();
+        priorityMap.put("a", 1); // normalized label
+
+        // Assign priority before calling method (important!)
+        java.lang.reflect.Method assignMethod =
+                LabelWithPriorityProcessor.class.getDeclaredMethod(
+                        "assignPriorities", List.class, Map.class);
+        assignMethod.setAccessible(true);
+        assignMethod.invoke(processor, rows, priorityMap);
+
+        // Access private method
+        java.lang.reflect.Method method =
+                LabelWithPriorityProcessor.class.getDeclaredMethod(
+                        "handlePriorityBasedSelection", List.class, Map.class, List.class);
+        method.setAccessible(true);
+
+        List<String> messages = new ArrayList<>();
+
+        SelectionFilteringInputTable winner =
+                (SelectionFilteringInputTable) method.invoke(processor, rows, priorityMap, messages);
+
+        assertNotNull(winner);
+        assertEquals("MEMBER_DETAILS_0", winner.getSorContainerInstance());
+
+        System.out.println("Winner Instance is "+winner.getSorContainerInstance());
+
+        for (SelectionFilteringInputTable row : rows) {
+            if (row.getSorContainerInstance().equals("MEMBER_DETAILS_0")) {
+                assertTrue(row.getLabelMatching());
+            } else {
+                assertFalse(row.getLabelMatching());
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
In selection priority, when the label matches, the paper number is now checked before validating against the minimum ID. I have updated this behavior in the instance.