### PR TITLE
Removed keywords from primary address code is added

### DIFF
--- a/src/main/java/in/handyman/raven/lib/model/deepSiftSearch/DeepSiftSearchConsumerProcess.java
+++ b/src/main/java/in/handyman/raven/lib/model/deepSiftSearch/DeepSiftSearchConsumerProcess.java
@@ -234,8 +234,6 @@ public class DeepSiftSearchConsumerProcess implements CoproProcessor.ConsumerPro
 
         String normalizedText = ocrText == null ? "" : ocrText.toLowerCase();
 
-        normalizedText = normalizedText.replaceAll("\\s+", " ").trim();
-
         List<String> allowedKeywords = new ArrayList<>();
         List<String> blockedKeywords = new ArrayList<>();
 
@@ -243,6 +241,12 @@ public class DeepSiftSearchConsumerProcess implements CoproProcessor.ConsumerPro
             if (keyword == null || keyword.trim().isEmpty()) continue;
 
             String normalizedKeyword = keyword.trim().toLowerCase();
+
+            if (isInsideAddress(normalizedText, keyword)) {
+                log.info(marker, "Keyword '{}' ignored as it appears inside address context", keyword);
+                continue;
+            }
+
             boolean isBlocked = false;
 
             for (BlockedKeywordRule rule : blockedRules) {
@@ -250,26 +254,31 @@ public class DeepSiftSearchConsumerProcess implements CoproProcessor.ConsumerPro
 
                 String[] labels = rule.getLabel().split("\\s*,\\s*");
 
-                String textWithoutAllLabels = normalizedText;
-
                 for (String label : labels) {
 
-                    if (!textWithoutAllLabels.contains(label)) continue;
+                    if (!normalizedText.contains(label)) continue;
 
-                    textWithoutAllLabels = textWithoutAllLabels.replaceAll(
-                            Pattern.quote(label.toLowerCase()), "");
-                }
+                    String textWithoutPhrase = normalizedText.replaceAll(
+                            "\\b" + Pattern.quote(label) + "\\b", "");
 
-                boolean existsElsewhere = Pattern.compile("\\b" + Pattern.quote(normalizedKeyword) + "\\b")
-                        .matcher(textWithoutAllLabels)
-                        .find();
+                    boolean existsElsewhere = Pattern.compile("\\b" + Pattern.quote(normalizedKeyword) + "\\b")
+                            .matcher(textWithoutPhrase)
+                            .find();
 
-                if (!existsElsewhere) {
-                    blockedKeywords.add(keyword);
-                    log.info(marker, "Blocked keyword '{}' only found inside labels '{}'", keyword, Arrays.toString(labels));
-                    isBlocked = true;
-                } else {
-                    log.info(marker, "Keyword '{}' still exists outside labels '{}', not blocking", keyword, Arrays.toString(labels));
+                    if (isInsideAddress(normalizedText, keyword)) {
+                        log.info(marker, "Keyword '{}' ignored as it appears inside address context", keyword);
+                        continue;
+                    }
+
+                    if (!existsElsewhere) {
+                        blockedKeywords.add(keyword);
+                        log.info(marker, "Blocked keyword '{}' only found inside phrase '{}'", keyword, label);
+                        isBlocked = true;
+                        break;
+                    }
+                    else {
+                        log.info(marker, "Keyword '{}' also exists outside phrase '{}', not blocking", keyword, rule.getLabel());
+                    }
                 }
             }
 
@@ -279,6 +288,43 @@ public class DeepSiftSearchConsumerProcess implements CoproProcessor.ConsumerPro
         }
 
         return new BlockingResult(allowedKeywords, blockedKeywords);
+    }
+
+    private boolean isInsideAddress(String text, String keyword) {
+
+        if (text == null || keyword == null ||
+                text.trim().isEmpty() || keyword.trim().isEmpty()) {
+            return false;
+        }
+
+        String lowerText = text.toLowerCase();
+        String lowerKeyword = keyword.toLowerCase();
+
+        for (String line : lowerText.split("\\n")) {
+
+            if (!line.contains(lowerKeyword)) {
+                continue;
+            }
+
+            boolean hasNumber = line.matches(".*\\b\\d{1,6}\\b.*");
+
+            boolean hasStreetWord = line.matches(
+                    ".*\\b(st|street|rd|road|ave|avenue|dr|drive|blvd|lane|ln|way|court|ct)\\b.*");
+
+            boolean hasStateZip = line.matches(
+                    ".*\\b[a-z]{2}\\b\\s+\\d{5}(-\\d{4})?.*");
+
+            boolean hasSuite = line.matches(
+                    ".*\\b(suite|ste|unit|apt)\\b.*");
+
+            if ((hasNumber && hasStreetWord) ||
+                    hasStateZip ||
+                    (hasSuite && hasNumber)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private String getBelowMinPageLengthFlag(String text) {

--- a/src/test/java/in/handyman/raven/lib/tritonservertest/DeepSiftSearchConsumerProcessTest.java
+++ b/src/test/java/in/handyman/raven/lib/tritonservertest/DeepSiftSearchConsumerProcessTest.java
@@ -1,0 +1,162 @@
+package in.handyman.raven.lib.tritonservertest;
+
+import in.handyman.raven.lib.model.deepSiftSearch.DeepSiftSearchConsumerProcess;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DeepSiftSearchConsumerProcessTest {
+
+    /**
+     * Helper method to invoke private method:
+     * isInsideAddress(String text, String keyword)
+     */
+    private boolean invokeIsInsideAddress(String text, String keyword) throws Exception {
+
+        DeepSiftSearchConsumerProcess process =
+                DeepSiftSearchConsumerProcess.builder()
+                        .log(null)
+                        .marker(null)
+                        .action(null)
+                        .pageContentMinLength(10)
+                        .build();
+
+        Method method = DeepSiftSearchConsumerProcess.class
+                .getDeclaredMethod("isInsideAddress", String.class, String.class);
+
+        method.setAccessible(true);
+
+        return (boolean) method.invoke(process, text, keyword);
+    }
+
+    // ==================================================
+    // VALID ADDRESS TEST CASES
+    // ==================================================
+
+    @Test
+    public void testStreetAddress_ST() throws Exception {
+        assertTrue(invokeIsInsideAddress(
+                "1400 16th St, San Francisco, CA 94103",
+                "ST"));
+    }
+
+    @Test
+    public void testRoadAddress_RD() throws Exception {
+        assertTrue(invokeIsInsideAddress(
+                "123 Main Rd, Dallas TX 75001",
+                "RD"));
+    }
+
+    @Test
+    public void testDriveAddress_IA() throws Exception {
+        assertTrue(invokeIsInsideAddress(
+                "6445 Corporate Dr., Johnston, IA 50131",
+                "IA"));
+    }
+
+    @Test
+    public void testWalkerStreet() throws Exception {
+        assertTrue(invokeIsInsideAddress(
+                "7901 Walker St",
+                "Walker"));
+    }
+
+    // ==================================================
+    // NON ADDRESS CASES
+    // ==================================================
+
+    @Test
+    public void testRollingWalker_ShouldBeFalse() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "Assistive Devices: Platform Rolling Walker, Rolling Walker",
+                "Walker"));
+    }
+
+    @Test
+    public void testTelemetry_ShouldBeFalse() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "Telemetry service required",
+                "Telemetry"));
+    }
+
+    @Test
+    public void testInpatient_ShouldBeFalse() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "Planned inpatient service",
+                "inpatient"));
+    }
+
+    @Test
+    public void testUrgent_ShouldBeFalse() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "Urgent authorization request",
+                "urgent"));
+    }
+
+    // ==================================================
+    // KEYWORD NOT FOUND
+    // ==================================================
+
+    @Test
+    public void testKeywordNotPresent() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "1400 16th St San Francisco",
+                "Walker"));
+    }
+
+    // ==================================================
+    // CASE INSENSITIVE
+    // ==================================================
+
+    @Test
+    public void testCaseInsensitive() throws Exception {
+        assertTrue(invokeIsInsideAddress(
+                "1400 16TH st SAN FRANCISCO ca 94103",
+                "St"));
+    }
+
+    // ==================================================
+    // EDGE CASES
+    // ==================================================
+
+    @Test
+    public void testOnlyStreet_NoNumber() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "Main Street",
+                "Street"));
+    }
+
+    @Test
+    public void testOnlyNumber() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "12345",
+                "12345"));
+    }
+
+    @Test
+    public void testHospitalName_StMary() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "St Mary Hospital",
+                "St"));
+    }
+
+    @Test
+    public void testEmptyText() throws Exception {
+        assertFalse(invokeIsInsideAddress(
+                "",
+                "ST"));
+    }
+
+    // ==================================================
+    // MULTILINE ADDRESS
+    // ==================================================
+
+    @Test
+    public void testMultilineAddress() throws Exception {
+        assertTrue(invokeIsInsideAddress(
+                "Labcorp Genetics Inc\n1400 16th St\nSan Francisco CA 94103",
+                "ST"));
+    }
+}


### PR DESCRIPTION
I verified whether the extracted keywords match address patterns. If a keyword originates from an address pattern, it is removed, as the client does not want keywords derived from address components. For example, abbreviations like “ST” (Street) or terms such as “IA” and “Walker” are excluded when identified as part of an address.